### PR TITLE
Changes for arm64 kernel cross compilation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:18.04
 
 ENV HOME /root
 
-RUN apt update && apt install -y \
+RUN echo "nameserver 8.8.8.8" > /etc/resolv.conf && apt update && apt install -y \
 	build-essential \
 	kmod \
 	nano \
@@ -16,7 +16,8 @@ RUN apt update && apt install -y \
 	# - required by kernel v4.15
 	libssl-dev \
 	# - required by kernel v4.16
-	bison flex
+	bison flex \
+	gcc-aarch64-linux-gnu
 
 
 
@@ -36,13 +37,13 @@ WORKDIR $HOME/linux
 ##     - kernel: For Pi 1, Pi Zero, Pi Zero W, or Compute Module
 ARG KERNEL=kernel7
 ENV KERNEL=${KERNEL}
-RUN make ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- bcm2709_defconfig
-RUN wget https://letstrust.de/uploads/letstrust-tpm-overlay.dts -O arch/arm/boot/dts/overlays/letstrust-tpm-overlay.dts
+RUN make ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- bcmrpi3_defconfig
+RUN wget https://letstrust.de/uploads/letstrust-tpm-overlay.dts -O arch/arm64/boot/dts/overlays/letstrust-tpm-overlay.dts
 COPY kernel/.config.patch .
 RUN cat .config.patch >> .config
 
 # - Build the kernel
-RUN make ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- zImage modules dtbs overlays/letstrust-tpm.dtbo -j8
+RUN make ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- Image modules dtbs -j8
 
 # - Prepare the deploy-to-sd-card script
 COPY install_kernel.sh .
@@ -50,4 +51,4 @@ RUN chmod u+x install_kernel.sh
 COPY kernel/config.txt.patch /tmp
 
 # - Install kernel to sd card
-ENTRYPOINT ["./install_kernel.sh", ${KERNEL}]
+#ENTRYPOINT ["./install_kernel.sh", ${KERNEL}]

--- a/install_kernel.sh
+++ b/install_kernel.sh
@@ -1,22 +1,22 @@
 #!/usr/bin/env bash
 
-KERNEL=${1:-kernel7}
+KERNEL=${1:-kernel8}
 
 SDCARD_BOOT_PATH=/media/boot
 SDCARD_ROOT_PATH=/media/root
 
 # - Build and install modules
-make ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- INSTALL_MOD_PATH=$SDCARD_ROOT_PATH modules_install
+make ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- INSTALL_MOD_PATH=$SDCARD_ROOT_PATH modules_install
 
 # - Backup old kernel
 cp $SDCARD_BOOT_PATH/$KERNEL.img $SDCARD_BOOT_PATH/$KERNEL-backup.img
 
 # - Deploy kernel
-cp arch/arm/boot/zImage $SDCARD_BOOT_PATH/$KERNEL.img
+cp arch/arm64/boot/Image $SDCARD_BOOT_PATH/$KERNEL.img
 # - Deploy dts overlays
-cp arch/arm/boot/dts/*.dtb $SDCARD_BOOT_PATH/
-cp arch/arm/boot/dts/overlays/*.dtb* $SDCARD_BOOT_PATH/overlays/
-cp arch/arm/boot/dts/overlays/README $SDCARD_BOOT_PATH/overlays/
+cp "arch/arm64/boot/dts/broadcom/"*.dtb $SDCARD_BOOT_PATH/
+cp "arch/arm64/boot/dts/overlays/"*.dtb* $SDCARD_BOOT_PATH/overlays/
+cp arch/arm64/boot/dts/overlays/README $SDCARD_BOOT_PATH/overlays/
 
 # - Enable tpm within config.txt (only apply the path as long as config.txt did not change)
-patch $SDCARD_BOOT_PATH/config.txt -i /tmp/config.txt.patch
+#patch $SDCARD_BOOT_PATH/config.txt -i /tmp/config.txt.patch


### PR DESCRIPTION
Entrypoint not working, 
Workaround: (sudo docker run -it --volume $SDCARD_BOOT_PATH:/media/boot --volume $SDCARD_ROOT_PATH:/media/root rpi_tpm_kernel_builder ./install_kernel.sh)
patch command in install_kernel.sh was also not working